### PR TITLE
Fix GitHub ribbon image not found

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -583,7 +583,7 @@
         </div>
       </div>
     </div>
-    <a href="https://github.com/arvida/emoji-cheat-sheet.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/arvida/emoji-cheat-sheet.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
     <div id="flash-test"></div>
     <div id="footer">
       <p>This page was created by <a href="http://arvidandersson.se">Arvid Andersson</a> /


### PR DESCRIPTION
On http://www.emoji-cheat-sheet.com the top right GitHub ribbon image has disappeared.

That's because https://a248.e.akamai.net/assets.github.com/img/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67 is a dead link. They probably moved the image.

I replaced this url with the one of the black ribbon from there: https://github.com/blog/273-github-ribbons

I have no idea which color it was originally, so you might need to pick another one.
