### PR TITLE
Fix "source" directive in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org/'
 gem 'fog'
 gem 'mime-types'
 gem 'rake'


### PR DESCRIPTION
This fixes the following annoyance from Bundler: "The source `:rubygems` is deprecated because HTTP requests are insecure. Please change your source to `'https://rubygems.org'` if possible, or `'http://rubygems.org'` if not."
