### PR TITLE
Add reference to Trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Do the fork and pull request dance.
 * [HenrikJoreteg](https://github.com/HenrikJoreteg)
 * [KamranMackey](https://github.com/KamranMackey)
 * [fusion94](https://github.com/fusion94)
+* [streeter](https://github.com/streeter)

--- a/public/index.html
+++ b/public/index.html
@@ -1017,9 +1017,10 @@
         <a href="https://github.com/mattrobenolt">mattrobenolt</a>,
         <a href="https://github.com/wdaher">wdaher</a>,
         <a href="https://github.com/HenrikJoreteg">HenrikJoreteg</a>,
-        <a href="https://github.com/KamranMackey">KamranMackey</a>
-        <a href="https://github.com/fusion94">fusion94</a> and
-        <a href="https://github.com/rocketslide">rocketslide</a>.
+        <a href="https://github.com/KamranMackey">KamranMackey</a>,
+        <a href="https://github.com/fusion94">fusion94</a>,
+        <a href="https://github.com/rocketslide">rocketslide</a> and
+        <a href="https://github.com/streeeter">streeter</a>
       </p>
       <p>
         &#x2714; Emoji-cheat-sheet.com is not affiliated with 37signals, LLC. or GitHub Inc. in any way.


### PR DESCRIPTION
Trello [now supports](http://blog.trello.com/emoji-and-markdown-everywhere/) emoji in their markdown.
