### PR TITLE
Idobata also supports emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :sparkles: :heart: Emoji-Cheat-Sheet.com :heart: :sparkles:
 
-A one pager listing the different emoji emoticons supported on [Campfire](http://campfirenow.com/), [GitHub](http://github.com/), [Basecamp Next](http://37signals.com/basecampnext/), [Teambox](http://teambox.com), [Turntable.fm](http://turntable.fm/), [Flowdock](https://www.flowdock.com/), [Sprint.ly](https://sprint.ly/), [GitLab](http://gitlab.org), [Kandan](http://kandanapp.com), [andbang](http://next.andbang.com), [Trello](https://trello.com/), [Hall](https://hall.com/), [Qiita](http://qiita.com), [Trello](http://trello.com), [Zendesk](http://zendesk.com), [Ruby-China](http://ruby-china.org/) and [Grove](https://grove.io/).
+A one pager listing the different emoji emoticons supported on [Campfire](http://campfirenow.com/), [GitHub](http://github.com/), [Basecamp Next](http://37signals.com/basecampnext/), [Teambox](http://teambox.com), [Turntable.fm](http://turntable.fm/), [Flowdock](https://www.flowdock.com/), [Sprint.ly](https://sprint.ly/), [GitLab](http://gitlab.org), [Kandan](http://kandanapp.com), [andbang](http://next.andbang.com), [Trello](https://trello.com/), [Hall](https://hall.com/), [Qiita](http://qiita.com), [Trello](http://trello.com), [Zendesk](http://zendesk.com), [Ruby-China](http://ruby-china.org/), [Grove](https://grove.io/) and [Idobata](https://idobata.io/).
 
 :point_right: Check them out at our home page: http://emoji-cheat-sheet.com.
 

--- a/public/index.html
+++ b/public/index.html
@@ -45,8 +45,9 @@
       <a href="http://plug.dj/">plug.dj</a>,
       <a href="http://qiita.com/">Qiita</a>,
       <a href="http://www.zendesk.com/">Zendesk</a>,
-      <a href="http://ruby-china.org/">Ruby China</a>
-      and <a href="https://grove.io/">Grove</a>.<br>
+      <a href="http://ruby-china.org/">Ruby China</a>,
+      <a href="https://grove.io/">Grove</a>
+      and <a href="https://idobata.io/">Idobata</a>.<br>
       However some of the emoji codes are not super easy to remember, <em>so here is a little cheat sheet</em>.<br>
       &#x2708; <b>Got flash enabled? Click the emoji code and it will be copied to your clipboard.</b>
     </p>


### PR DESCRIPTION
Idobata is a Campfire-ish webchat (still in beta and mainly targeted at :jp: users for now) which actually fully supports emojis via :octocat: github/gemoji :metal:
