### PR TITLE
Remove turntable.fm from lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :sparkles: :heart: Emoji-Cheat-Sheet.com :heart: :sparkles:
 
-A one pager listing the different emoji emoticons supported on [Campfire](http://campfirenow.com/), [GitHub](http://github.com/), [Basecamp Next](http://37signals.com/basecampnext/), [Teambox](http://teambox.com/), [Turntable.fm](http://turntable.fm/), [Plug.dj](http://plug.dj/), [Flowdock](https://www.flowdock.com/), [Sprint.ly](https://sprint.ly/), [GitLab](http://gitlab.org/), [Kandan](http://kandanapp.com/), [andbang](http://next.andbang.com/), [Trello](https://trello.com/), [Hall](https://hall.com/), [Qiita](http://qiita.com/), [Trello](http://trello.com/), [Zendesk](http://zendesk.com/), [Ruby-China](http://ruby-china.org/), [Grove](https://grove.io/) and [Idobata](https://idobata.io/).
+A one pager listing the different emoji emoticons supported on [Campfire](http://campfirenow.com/), [GitHub](http://github.com/), [Basecamp Next](http://37signals.com/basecampnext/), [Teambox](http://teambox.com/), [Plug.dj](http://plug.dj/), [Flowdock](https://www.flowdock.com/), [Sprint.ly](https://sprint.ly/), [GitLab](http://gitlab.org/), [Kandan](http://kandanapp.com/), [andbang](http://next.andbang.com/), [Trello](https://trello.com/), [Hall](https://hall.com/), [Qiita](http://qiita.com/), [Trello](http://trello.com/), [Zendesk](http://zendesk.com/), [Ruby-China](http://ruby-china.org/), [Grove](https://grove.io/) and [Idobata](https://idobata.io/).
 
 :point_right: Check them out at our home page: http://emoji-cheat-sheet.com.
 

--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,6 @@
       <a href="http://campfirenow.com/">Campfire</a>,
       <a href="http://github.com/">GitHub</a>,
       <a href="http://basecamp.com/">Basecamp</a>,
-      <a href="http://turntable.fm/">Turntable.fm</a>,
       <a href="http://teambox.com/">Teambox</a>,
       <a href="http://trac-hacks.org/wiki/TracEmojiPlugin">Trac</a>,
       <a href="https://www.flowdock.com/">Flowdock</a>,


### PR DESCRIPTION
turntable.fm recently went defunct (now it's Turntable Live, which as far as I can tell doesn't have text chat with emoji support) so I removed it from the list.

RIP turntable.fm, I knew ye well.
