### PR TITLE
Added Discourse to the list and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ A one pager listing the different emoji emoticons supported on
 [Campfire](http://campfirenow.com/),
 [GitHub](http://github.com/),
 [Basecamp Next](http://37signals.com/basecampnext/),
-[Bonusly](https://bonus.ly)
 [Redbooth](http://redbooth.com/),
-[Plug.dj](http://plug.dj/),
+[Trac](http://trac-hacks.org/wiki/TracEmojiPlugin),
 [Flowdock](https://www.flowdock.com/),
 [Sprint.ly](https://sprint.ly/),
-[Redmine](https://github.com/tmy/redmine_gemoji),
 [Kandan](http://kandanapp.com/),
-[andbang](http://next.andbang.com/),
+[Textbox.io](https://textbox.io/),
+[Kippt](http://kippt.com),
+[Redmine](https://github.com/tmy/redmine_gemoji),
+[JabbR](http://about.jabbr.net/),
 [Trello](https://trello.com/),
 [Hall](https://hall.com/),
+[Plug.dj](http://plug.dj/),
 [Qiita](http://qiita.com/),
 [Zendesk](http://zendesk.com/),
 [Ruby-China](http://ruby-china.org/),
@@ -22,16 +24,21 @@ A one pager listing the different emoji emoticons supported on
 [NodeBB Forums](https://nodebb.org),
 [Slack](https://slack.com),
 [Streamup](https://streamup.com/),
-[Quip](https://quip.com),
 [OrganisedMinds](http://organisedminds.com),
 [Hackpad](https://hackpad.com),
+[Cryptbin](https://cryptbin.com/),
 [Kato](https://kato.im),
 [Reportedly](http://reportedly.co),
 [Cheerful Ghost](http://cheerfulghost.com),
 [IRCCloud](https://www.irccloud.com),
 [Dashcube](https://dashcube.com),
 [MyVideoGameList](http://myvideogamelist.com),
-& [Subrosa](https://subrosa.io).
+[Subrosa](https://subrosa.io),
+[Sococo](https://www.sococo.com),
+[Quip](https://quip.com),
+[And Bang](https://andbang.com)
+[Bonusly](https://bonus.ly),
+& [Discourse](https://discourse.org).
 
 :point_right: Check them out at our home page: http://emoji-cheat-sheet.com.
 
@@ -97,3 +104,4 @@ Do the fork and pull request dance.
 * [GrahamCampbell](https://github.com/GrahamCampbell)
 * [alirayl](https://github.com/alirayl)
 * [hnrc](https://github.com/hnrc)
+* [awesomerobot](https://github.com/awesomerobot)

--- a/public/index.html
+++ b/public/index.html
@@ -62,8 +62,12 @@
       <a href="http://myvideogamelist.com">MyVideoGameList</a>,
       <a href="https://subrosa.io">Subrosa</a>,
       <a href="https://www.sococo.com">Sococo</a>,
-      and <a href="https://bonus.ly">Bonusly</a>.<br>
-
+      <a href="https://quip.com">Quip</a>,
+      <a href="https://andbang.com">And Bang</a>,
+      <a href="https://bonus.ly">Bonusly</a>,
+      and <a href="https://discourse.org">Discourse</a>.<br>
+    </p>
+    <p>
       However some of the emoji codes are not super easy to remember, <em>so here is a little cheat sheet</em>.<br>
       &#x2708; <b>Got flash enabled? Click the emoji code and it will be copied to your clipboard.</b>
     </p>
@@ -1057,8 +1061,10 @@
         <a href="https://github.com/take">take</a>,
         <a href="https://github.com/nicholasserra">nicholasserra</a>,
         <a href="https://github.com/MichaelBanks">MichaelBanks</a>,
-        <a href="https://github.com/GrahamCampbell">GrahamCampbell</a> and
-        <a href="https://github.com/hnrc">hnrc</a>.
+        <a href="https://github.com/GrahamCampbell">GrahamCampbell</a>,
+        <a href="https://github.com/hnrc">hnrc</a>, and
+        <a href="https://github.com/awesomerobot">awesomerobot</a>.
+
       </p>
       <p>
         &#x2714; Emoji-cheat-sheet.com is not affiliated with 37signals, LLC. or GitHub Inc. in any way.
@@ -1067,7 +1073,7 @@
         &#x267A; Built using bits from
         <a href="http://www.steamdev.com/zclip">zClip</a>,
         <a href="http://subtlepatterns.com/">SubtlePatterns</a>,
-        <a href="http://www.givainc.com/labs/jnotify_jquery_plugin.htm">jnotify</a> and
+        <a href="http://www.givainc.com/labs/jnotify_jquery_plugin.htm">jnotify</a>, and
         <a href="http://listjs.com/">list.js</a>.
       </p>
       <a href="https://github.com/arvida/emoji-cheat-sheet.com">


### PR DESCRIPTION
Other small fixes include: 
- Both readme and index supported sites lists are in the same order and have the same sites
- And Bang was in readme with a broken link, but not in index. Fixed link and added to index.
- Consistent use of the oxford comma
- Supported sites list and "However some of the emoji codes are not super easy to remember..." have their own respective paragraph tags 
- Added myself to contributors list 

:cake:
