### PR TITLE
Add Dokuwiki to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ A one pager listing the different emoji emoticons supported on
 [Damn Bugs](https://bugtrack.in),
 [Let's Chat](https://sdelements.github.io/lets-chat),
 [Buildkite](https://buildkite.com)
-& [IGDB.com](https://www.igdb.com/forums)
+[IGDB.com](https://www.igdb.com/forums),
+& [Dokuwiki](https://github.com/squarefractal/githubemoji-dokuwiki)
 
 :point_right: Check them out at our home page: http://emoji-cheat-sheet.com.
 

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,8 @@
       <a href="https://www.bugtrack.in">Damn Bugs</a>,
       <a href="https://sdelements.github.io/lets-chat">Let's Chat</a>,
       <a href="https://buildkite.com">Buildkite</a>,
-      and <a href="https://chatgrape.com/">ChatGrape</a>.<br>
+      <a href="https://chatgrape.com/">ChatGrape</a>,<br>
+      and <a href="https://github.com/squarefractal/githubemoji-dokuwiki">Dokuwiki</a>.<br>
     </p>
 
     <p>


### PR DESCRIPTION
This PR adds Dokuwiki to the list of websites and software supporting this emoji scheme.

The linked address is actually a shell script that installs the emoji set, but since the Trac and Redmine support is also via plugins, I would assume that non-native support is also considered acceptable.

Full disclosure: I am the author of the said shell script.