### PR TITLE
Remove out of place string

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -452,7 +452,7 @@
       <li><div><img src="graphics/emojis/cd.png"> :<span class="name">cd</span>:</div></li>
       <li><div><img src="graphics/emojis/dvd.png"> :<span class="name">dvd</span>:</div></li>
       <li><div><img src="graphics/emojis/floppy_disk.png"> :<span class="name">floppy_disk</span>:</div></li>
-      <li><div><img src="graphics/emojis/camera.png"> :<span class="name">camera</span>:</div></li>gam
+      <li><div><img src="graphics/emojis/camera.png"> :<span class="name">camera</span>:</div></li>
       <li><div><img src="graphics/emojis/video_camera.png"> :<span class="name">video_camera</span>:</div></li>
       <li><div><img src="graphics/emojis/movie_camera.png"> :<span class="name">movie_camera</span>:</div></li>
       <li><div><img src="graphics/emojis/computer.png"> :<span class="name">computer</span>:</div></li>


### PR DESCRIPTION
I found a string which is out of place so that I removed the lost child.

<img width="1089" alt="2015-11-07 20 10 57" src="https://cloud.githubusercontent.com/assets/1811616/11014868/dd62b53a-858b-11e5-8bb6-5871103a5517.png">
