### PR TITLE
Add alternative names for symbols

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -857,22 +857,22 @@
       <li><div><img src="graphics/emojis/up.png">:<span class="name" data-alternative-name="blue-square, above, high">up</span>:</div></li>
       <li><div><img src="graphics/emojis/cool.png">:<span class="name" data-alternative-name="words, blue-square">cool</span>:</div></li>
       <li><div><img src="graphics/emojis/free.png">:<span class="name" data-alternative-name="blue-square, words">free</span>:</div></li>
-      <li><div><img src="graphics/emojis/ng.png">:<span class="name" data-alternative-name="blue-square, words, shape, icon">ng</span>:</div></li>
+      <li><div><img src="graphics/emojis/ng.png">:<span class="name" data-alternative-name="blue-square, words, shape, icon, no-good, not-good">ng</span>:</div></li>
       <li><div><img src="graphics/emojis/cinema.png">:<span class="name" data-alternative-name="movie, blue-square, record, film">cinema</span>:</div></li>
       <li><div><img src="graphics/emojis/koko.png">:<span class="name" data-alternative-name="blue-square, here, katakana, japanese, destination">koko</span>:</div></li>
       <li><div><img src="graphics/emojis/signal_strength.png">:<span class="name" data-alternative-name="blue-square, reception, phone, internet, connection, wifi, bluetooth">signal_strength</span>:</div></li>
-      <li><div><img src="graphics/emojis/u5272.png">:<span class="name" data-alternative-name="wari, cut, divide, chinese, kanji, pink-square">u5272</span>:</div></li>
-      <li><div><img src="graphics/emojis/u5408.png">:<span class="name" data-alternative-name="japanese, chinese, join, kanji, red-square">u5408</span>:</div></li>
-      <li><div><img src="graphics/emojis/u55b6.png">:<span class="name" data-alternative-name="ying, japanese, opening hours, orange-square">u55b6</span>:</div></li>
-      <li><div><img src="graphics/emojis/u6307.png">:<span class="name" data-alternative-name="zhǐ, zhi, chinese, point, green-square, kanji">u6307</span>:</div></li>
+      <li><div><img src="graphics/emojis/u5272.png">:<span class="name" data-alternative-name="wari, cut, divide, discount, chinese, kanji, pink-square">u5272</span>:</div></li>
+      <li><div><img src="graphics/emojis/u5408.png">:<span class="name" data-alternative-name="japanese, chinese, join, kanji, red-square, passed, approved">u5408</span>:</div></li>
+      <li><div><img src="graphics/emojis/u55b6.png">:<span class="name" data-alternative-name="ying, japanese, opening hours, in-business, orange-square">u55b6</span>:</div></li>
+      <li><div><img src="graphics/emojis/u6307.png">:<span class="name" data-alternative-name="zhǐ, zhi, chinese, point, green-square, kanji, reserved">u6307</span>:</div></li>
       <li><div><img src="graphics/emojis/u6708.png">:<span class="name" data-alternative-name="yuè, yue, chinese, month, moon, japanese, orange-square, kanji">u6708</span>:</div></li>
-      <li><div><img src="graphics/emojis/u6709.png">:<span class="name" data-alternative-name="yǒu, you, orange-square, chinese, have, kanji">u6709</span>:</div></li>
+      <li><div><img src="graphics/emojis/u6709.png">:<span class="name" data-alternative-name="yǒu, you, orange-square, chinese, have, available, in-stock, kanji">u6709</span>:</div></li>
       <li><div><img src="graphics/emojis/u6e80.png">:<span class="name" data-alternative-name="mitsuru, full, chinese, japanese, red-square, kanji">u6e80</span>:</div></li>
-      <li><div><img src="graphics/emojis/u7121.png">:<span class="name" data-alternative-name="wú, wu, nothing, chinese, kanji, japanese, orange-square">u7121</span>:</div></li>
-      <li><div><img src="graphics/emojis/u7533.png">:<span class="name" data-alternative-name="shēn, shen, chinese, japanese, kanji, orange-square">u7533</span>:</div></li>
-      <li><div><img src="graphics/emojis/u7a7a.png">:<span class="name" data-alternative-name="kōng, kong, kanji, japanese, chinese, empty, sky, blue-square">u7a7a</span>:</div></li>
+      <li><div><img src="graphics/emojis/u7121.png">:<span class="name" data-alternative-name="wú, wu, nothing, out-of-stock, unavailable, chinese, kanji, japanese, orange-square">u7121</span>:</div></li>
+      <li><div><img src="graphics/emojis/u7533.png">:<span class="name" data-alternative-name="shēn, shen, chinese, japanese, kanji, orange-square, apply-here, application">u7533</span>:</div></li>
+      <li><div><img src="graphics/emojis/u7a7a.png">:<span class="name" data-alternative-name="kōng, kong, kanji, japanese, chinese, empty, sky, blue-square, vacant">u7a7a</span>:</div></li>
       <li><div><img src="graphics/emojis/u7981.png">:<span class="name" data-alternative-name="jìn, jin, kanji, japanese, chinese, forbidden, limit, restricted, red-square">u7981</span>:</div></li>
-      <li><div><img src="graphics/emojis/sa.png">:<span class="name" data-alternative-name="japanese, blue-square, katakana">sa</span>:</div></li>
+      <li><div><img src="graphics/emojis/sa.png">:<span class="name" data-alternative-name="japanese, blue-square, katakana, service, free">sa</span>:</div></li>
       <li><div><img src="graphics/emojis/restroom.png">:<span class="name" data-alternative-name="blue-square, toilet, refresh, wc, gender">restroom</span>:</div></li>
       <li><div><img src="graphics/emojis/mens.png">:<span class="name" data-alternative-name="toilet, restroom, wc, blue-square, gender, male">mens</span>:</div></li>
       <li><div><img src="graphics/emojis/womens.png">:<span class="name" data-alternative-name="purple-square, woman, female, toilet, loo, restroom, gender">womens</span>:</div></li>
@@ -887,13 +887,13 @@
       <li><div><img src="graphics/emojis/potable_water.png">:<span class="name" data-alternative-name="blue-square, liquid, restroom, cleaning, faucet">potable_water</span>:</div></li>
       <li><div><img src="graphics/emojis/put_litter_in_its_place.png">:<span class="name" data-alternative-name="blue-square, sign, human, info">put_litter_in_its_place</span>:</div></li>
       <li><div><img src="graphics/emojis/secret.png">:<span class="name" data-alternative-name="privacy, chinese, sshh, kanji, red-circle">secret</span>:</div></li>
-      <li><div><img src="graphics/emojis/congratulations.png">:<span class="name" data-alternative-name="chinese, kanji, japanese, red-circle">congratulations</span>:</div></li>
+      <li><div><img src="graphics/emojis/congratulations.png">:<span class="name" data-alternative-name="chinese, kanji, japanese, red-circle, celebration">congratulations</span>:</div></li>
       <li><div><img src="graphics/emojis/m.png">:<span class="name" data-alternative-name="alphabet, blue-circle, letter">m</span>:</div></li>
       <li><div><img src="graphics/emojis/passport_control.png">:<span class="name" data-alternative-name="custom, blue-square">passport_control</span>:</div></li>
       <li><div><img src="graphics/emojis/left_luggage.png">:<span class="name" data-alternative-name="blue-square, travel">left_luggage</span>:</div></li>
       <li><div><img src="graphics/emojis/customs.png">:<span class="name" data-alternative-name="passport, border, blue-square">customs</span>:</div></li>
       <li><div><img src="graphics/emojis/ideograph_advantage.png">:<span class="name" data-alternative-name="chinese, kanji, obtain, get, circle">ideograph_advantage</span>:</div></li>
-      <li><div><img src="graphics/emojis/cl.png">:<span class="name" data-alternative-name="alphabet, words, red-square">cl</span>:</div></li>
+      <li><div><img src="graphics/emojis/cl.png">:<span class="name" data-alternative-name="alphabet, words, red-square, clear">cl</span>:</div></li>
       <li><div><img src="graphics/emojis/sos.png">:<span class="name" data-alternative-name="help, red-square, words, emergency, 911">sos</span>:</div></li>
       <li><div><img src="graphics/emojis/id.png">:<span class="name" data-alternative-name="purple-square, words">id</span>:</div></li>
       <li><div><img src="graphics/emojis/no_entry_sign.png">:<span class="name" data-alternative-name="forbid, stop, limit, denied, disallow, circle">no_entry_sign</span>:</div></li>
@@ -909,7 +909,7 @@
       <li><div><img src="graphics/emojis/sparkle.png">:<span class="name" data-alternative-name="stars, green-square, awesome, good, fireworks">sparkle</span>:</div></li>
       <li><div><img src="graphics/emojis/eight_pointed_black_star.png">:<span class="name" data-alternative-name="orange-square, shape, polygon">eight_pointed_black_star</span>:</div></li>
       <li><div><img src="graphics/emojis/heart_decoration.png">:<span class="name" data-alternative-name="heart, purple-square, love, like">heart_decoration</span>:</div></li>
-      <li><div><img src="graphics/emojis/vs.png">:<span class="name" data-alternative-name="words, orange-square">vs</span>:</div></li>
+      <li><div><img src="graphics/emojis/vs.png">:<span class="name" data-alternative-name="words, orange-square, versus">vs</span>:</div></li>
       <li><div><img src="graphics/emojis/vibration_mode.png">:<span class="name" data-alternative-name="orange-square, phone">vibration_mode</span>:</div></li>
       <li><div><img src="graphics/emojis/mobile_phone_off.png">:<span class="name" data-alternative-name="mute, orange-square, silence, quiet">mobile_phone_off</span>:</div></li>
       <li><div><img src="graphics/emojis/chart.png">:<span class="name" data-alternative-name="yen, green-square, graph, presentation, stats">chart</span>:</div></li>


### PR DESCRIPTION
Symbols: :ng:, :u5272:, :u5408:, :u55b6:, :u6307:, :u6709:, :u7121:, :u7533:, :u7a7a:, :sa:, :congratulations:, :cl: and :vs:.

Descriptions from http://www.iemoji.com

Rebase of #379 (fork had been deleted)